### PR TITLE
Fixing command(meta) click on macs

### DIFF
--- a/widget/Selection.js
+++ b/widget/Selection.js
@@ -1,5 +1,5 @@
-define(["dojo/_base/declare", "dojo/_base/array", "dojo/_base/lang", "dojo/Stateful"], 
-	function(declare, arr, lang, Stateful){
+define(["dojo/_base/declare", "dojo/_base/array", "dojo/sniff", "dojo/_base/lang", "dojo/Stateful"], 
+	function(declare, arr, has, lang, Stateful){
 		
 	return declare("dojox.widget.Selection", Stateful, {
 		// summary:
@@ -157,14 +157,14 @@ define(["dojo/_base/declare", "dojo/_base/array", "dojo/_base/lang", "dojo/State
 			var changed;
 			var oldSelectedItem = this.get("selectedItem");
 			var selected = item ? this.isItemSelected(item): false;
-			
+			var evtMultiSelectKey = has("mac") ? e.metaKey : e.ctrlKey;
 			if(item == null){
-				if(!e.ctrlKey && this.selectedItem != null){
+				if(!evtMultiSelectKey && this.selectedItem != null){
 					this.set("selectedItem", null);
 					changed = true;
 				}
 			}else if(this.selectionMode == "multiple"){
-				 if(e.ctrlKey){
+				 if(evtMultiSelectKey){
 					this.setItemSelected(item, !selected);
 					changed = true;
 				}else{
@@ -172,7 +172,7 @@ define(["dojo/_base/declare", "dojo/_base/array", "dojo/_base/lang", "dojo/State
 					changed = true;						
 				}				 								
 			}else{ // single
-				if(e.ctrlKey){					
+				if(evtMultiSelectKey){					
 					//if the object is selected deselects it.
 					this.set("selectedItem", selected ? null : item);
 					changed = true;					


### PR DESCRIPTION
Fixing an issue where any widget using Selection.js (such as dojox/Calendar) is only able to multi-select if you control-click, even on OSX. (Unfortunately for them, control-click also simulates the Windows right-click behavior, making the browser context menu appear.)

Easily demonstrated using OSX here: http://demos.dojotoolkit.org/dojox/calendar/tests/columnview.html

I opened the following bug ticket: https://bugs.dojotoolkit.org/ticket/18620

Notably, this is a duplicate of https://bugs.dojotoolkit.org/ticket/17664, but that was applied on the 2.0 branch and never put on the 1.x branch. You may want to use cjolif's patch instead, but either way it'd be great if we could multi-select on OSX in the 1.x branch!
